### PR TITLE
Avoid `new X()` in `Wallets_List_Table`

### DIFF
--- a/.github/workflows/unit-coverage.yml
+++ b/.github/workflows/unit-coverage.yml
@@ -152,8 +152,10 @@ jobs:
             touch gh-pages/.nojekyll
           fi
 
-      - name: Pre-commit `git pull`
-        run: git pull
+      - name: Pre-commit `git pull gh-pages`
+        run: |
+          cd gh-pages
+          git pull gh-pages
 
       - name: Commit HTML code coverage + badge to gh-pages
         if: ${{ matrix.php == env.COVERAGE_PHP_VERSION }}

--- a/.github/workflows/unit-coverage.yml
+++ b/.github/workflows/unit-coverage.yml
@@ -153,6 +153,7 @@ jobs:
           fi
 
       - name: Pre-commit `git pull gh-pages`
+        if: ${{ matrix.php == env.COVERAGE_PHP_VERSION }}
         run: |
           cd gh-pages
           git pull gh-pages

--- a/.github/workflows/unit-coverage.yml
+++ b/.github/workflows/unit-coverage.yml
@@ -156,7 +156,7 @@ jobs:
         if: ${{ matrix.php == env.COVERAGE_PHP_VERSION }}
         run: |
           cd gh-pages
-          git pull gh-pages
+          (git ls-remote --heads --exit-code origin gh-pages &>/dev/null) && (git checkout --progress --force -B gh-pages refs/remotes/origin/gh-pages)
 
       - name: Commit HTML code coverage + badge to gh-pages
         if: ${{ matrix.php == env.COVERAGE_PHP_VERSION }}

--- a/includes/api/repositories/class-bitcoin-wallet-repository.php
+++ b/includes/api/repositories/class-bitcoin-wallet-repository.php
@@ -7,6 +7,7 @@
 
 namespace BrianHenryIE\WP_Bitcoin_Gateway\API\Repositories;
 
+use BrianHenryIE\WP_Bitcoin_Gateway\Admin\Wallets_List_Table;
 use BrianHenryIE\WP_Bitcoin_Gateway\API\Model\Wallet\Bitcoin_Wallet;
 use BrianHenryIE\WP_Bitcoin_Gateway\API\Model\Wallet\Bitcoin_Wallet_WP_Post_Interface;
 use BrianHenryIE\WP_Bitcoin_Gateway\API\Repositories\Factories\Bitcoin_Wallet_Factory;
@@ -107,6 +108,16 @@ class Bitcoin_Wallet_Repository extends WP_Post_Repository_Abstract {
 	 */
 	public function get_by_wp_post_id( int $post_id ): Bitcoin_Wallet {
 		return $this->bitcoin_wallet_factory->get_by_wp_post_id( $post_id );
+	}
+
+	/**
+	 * @used-by Wallets_List_Table::get_bitcoin_wallet_object()
+	 *
+	 * @param WP_Post $post A WP_Post storing wallet information.
+	 * @throws UnknownCurrencyException If BTC is not correctly added to brick/money.
+	 */
+	public function get_by_wp_post( WP_Post $post ): Bitcoin_Wallet {
+		return $this->bitcoin_wallet_factory->get_by_wp_post( $post );
 	}
 
 	/**

--- a/includes/wp-includes/class-post-bh-bitcoin-wallet.php
+++ b/includes/wp-includes/class-post-bh-bitcoin-wallet.php
@@ -9,7 +9,9 @@
 
 namespace BrianHenryIE\WP_Bitcoin_Gateway\WP_Includes;
 
+use BrianHenryIE\WP_Bitcoin_Gateway\Admin\Wallets_List_Table;
 use BrianHenryIE\WP_Bitcoin_Gateway\API\Model\Wallet\Bitcoin_Wallet_WP_Post_Interface;
+use BrianHenryIE\WP_Bitcoin_Gateway\API\Repositories\Bitcoin_Wallet_Repository;
 use BrianHenryIE\WP_Bitcoin_Gateway\API_Interface;
 
 /**
@@ -18,24 +20,41 @@ use BrianHenryIE\WP_Bitcoin_Gateway\API_Interface;
  * @see register_post_type()
  * @see register_post_status()
  *
+ * @see Wallets_List_Table
  * @see wp-admin/edit.php?post_type=bh-bitcoin-wallet
+ *
+ * @see Bitcoin_Wallet_WP_Post_Interface
+ *
+ * @phpstan-import-type Wallet_List_Table_Dependencies_Array from Wallets_List_Table
  */
 class Post_BH_Bitcoin_Wallet {
 
 	/**
-	 * Array of plugin objects to pass to post types.
+	 * Dependencies to pass to the WP_Post_Type object for use by the list table.
 	 *
-	 * @var array{api:API_Interface} $plugin_objects
+	 * Stored on the post type args and accessible via:
+	 * `get_post_type_object( 'bh-bitcoin-wallet' )->dependencies`
+	 *
+	 * @see Wallets_List_Table::__construct() Consumer of these dependencies.
+	 *
+	 * @var array&Wallet_List_Table_Dependencies_Array $dependencies
 	 */
-	protected array $plugin_objects = array();
+	protected array $dependencies;
 
 	/**
 	 * Constructor
 	 *
-	 * @param API_Interface $api The main plugin functions.
+	 * @param API_Interface             $api The main plugin API for wallet operations.
+	 * @param Bitcoin_Wallet_Repository $bitcoin_wallet_repository To get the wallet details for the admin list table.
 	 */
-	public function __construct( API_Interface $api ) {
-		$this->plugin_objects['api'] = $api;
+	public function __construct(
+		API_Interface $api,
+		Bitcoin_Wallet_Repository $bitcoin_wallet_repository,
+	) {
+		$this->dependencies = array(
+			'api'                       => $api,
+			'bitcoin_wallet_repository' => $bitcoin_wallet_repository,
+		);
 	}
 
 	/**
@@ -52,15 +71,20 @@ class Post_BH_Bitcoin_Wallet {
 		);
 
 		$args = array(
-			'labels'         => $labels,
-			'description'    => 'Wallets used with WooCommerce Bitcoin gateways.',
-			'public'         => true,
-			'menu_position'  => 8,
-			'supports'       => array( 'title', 'thumbnail', 'excerpt', 'comments' ),
-			'has_archive'    => false,
-			'show_in_menu'   => false,
-			'plugin_objects' => $this->plugin_objects,
-			'show_in_rest'   => true,
+			'labels'        => $labels,
+			'description'   => 'Wallets used with WooCommerce Bitcoin gateways.',
+			'public'        => true,
+			'menu_position' => 8,
+			'supports'      => array( 'title', 'thumbnail', 'excerpt', 'comments' ),
+			'has_archive'   => false,
+			'show_in_menu'  => false,
+			'show_in_rest'  => true,
+			/**
+			 * Dependencies passed to the list table via the WP_Post_Type object.
+			 *
+			 * @see Wallets_List_Table::__construct() Where these are consumed.
+			 */
+			'dependencies'  => $this->dependencies,
 		);
 
 		register_post_type( Bitcoin_Wallet_WP_Post_Interface::POST_TYPE, $args );

--- a/tests/unit/wp-includes/class-post-bh-bitcoin-wallet-unit-Test.php
+++ b/tests/unit/wp-includes/class-post-bh-bitcoin-wallet-unit-Test.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Tests for Post_BH_Bitcoin_Wallet class.
+ *
+ * Verifies that the dependencies array is correctly structured and passed
+ * to register_post_type() for consumption by Wallets_List_Table.
+ *
+ * @package brianhenryie/bh-wp-bitcoin-gateway
+ */
+
+namespace BrianHenryIE\WP_Bitcoin_Gateway\WP_Includes;
+
+use BrianHenryIE\WP_Bitcoin_Gateway\API\Repositories\Bitcoin_Wallet_Repository;
+use BrianHenryIE\WP_Bitcoin_Gateway\API_Interface;
+use Codeception\Test\Unit;
+
+/**
+ * @coversDefaultClass \BrianHenryIE\WP_Bitcoin_Gateway\WP_Includes\Post_BH_Bitcoin_Wallet
+ */
+class Post_BH_Bitcoin_Wallet_Unit_Test extends Unit {
+
+	protected function setUp(): void {
+		parent::setUp();
+		\WP_Mock::setUp();
+	}
+
+	#[\Override]
+	protected function tearDown(): void {
+		parent::tearDown();
+		\WP_Mock::tearDown();
+	}
+
+	protected function get_sut(
+		?API_Interface $api = null,
+		?Bitcoin_Wallet_Repository $bitcoin_wallet_repository = null,
+	): Post_BH_Bitcoin_Wallet {
+		return new Post_BH_Bitcoin_Wallet(
+			api: $api ?? $this->makeEmpty( API_Interface::class ),
+			bitcoin_wallet_repository: $bitcoin_wallet_repository ?? $this->make( Bitcoin_Wallet_Repository::class ),
+		);
+	}
+
+	/**
+	 * Verify register_post_type is called with dependencies in args.
+	 *
+	 * @covers ::register_wallet_post_type
+	 */
+	public function test_register_wallet_post_type_passes_dependencies(): void {
+
+		$api                       = $this->makeEmpty( API_Interface::class );
+		$bitcoin_wallet_repository = $this->make( Bitcoin_Wallet_Repository::class );
+
+		$sut = $this->get_sut( $api, $bitcoin_wallet_repository );
+
+		$captured_args = null;
+
+		\WP_Mock::userFunction(
+			'register_post_type',
+		)->withArgs(
+			function ( $post_type, $args ) use ( &$captured_args ) {
+				$captured_args = $args;
+				return 'bh-bitcoin-wallet' === $post_type;
+			}
+		)->once()->andReturn( new \stdClass() );
+
+		\WP_Mock::userFunction(
+			'register_post_status',
+			array(
+				'times' => 2, // active, inactive.
+			)
+		);
+
+		\WP_Mock::passthruFunction( '_x' );
+
+		\WP_Mock::userFunction(
+			'_n_noop',
+			array(
+				'return' => array(),
+			)
+		);
+
+		$sut->register_wallet_post_type();
+
+		$this->assertNotNull( $captured_args, 'register_post_type should have been called' );
+
+		$this->assertArrayHasKey( 'dependencies', $captured_args );
+		$this->assertIsArray( $captured_args['dependencies'] );
+
+		$this->assertArrayHasKey( 'api', $captured_args['dependencies'] );
+		$this->assertSame( $api, $captured_args['dependencies']['api'] );
+
+		$this->assertArrayHasKey( 'bitcoin_wallet_repository', $captured_args['dependencies'] );
+		$this->assertSame( $bitcoin_wallet_repository, $captured_args['dependencies']['bitcoin_wallet_repository'] );
+	}
+}

--- a/tests/wpunit/admin/class-addresses-list-table-wpunit-Test.php
+++ b/tests/wpunit/admin/class-addresses-list-table-wpunit-Test.php
@@ -63,21 +63,24 @@ class Addresses_List_Table_WPUnit_Test extends \lucatume\WPBrowser\TestCase\WPTe
 
 		\WC_Payment_Gateways::instance()->payment_gateways['bh_bitcoin'] = $bitcoin_gateway;
 
-		// Hopefully this is reset between tests?
-		$plugin_post_address_type = new Post_BH_Bitcoin_Address( $api );
+		$json_mapper = new JsonMapper_Helper()->build();
+		$logger      = new ColorLogger();
+
+		$bitcoin_address_factory    = new Bitcoin_Address_Factory( $json_mapper, $logger );
+		$bitcoin_address_repository = new Bitcoin_Address_Repository( $bitcoin_address_factory );
+
+		$bitcoin_wallet_factory    = new Bitcoin_Wallet_Factory();
+		$bitcoin_wallet_repository = new Bitcoin_Wallet_Repository( $bitcoin_wallet_factory );
+
+		$plugin_post_address_type = new Post_BH_Bitcoin_Address( $api, $bitcoin_address_repository, $bitcoin_wallet_repository );
 		$plugin_post_address_type->register_address_post_type();
-		$plugin_post_wallet_type = new Post_BH_Bitcoin_Wallet( $api );
+		$plugin_post_wallet_type = new Post_BH_Bitcoin_Wallet( $api, $bitcoin_wallet_repository );
 		$plugin_post_wallet_type->register_wallet_post_type();
 
 		$address       = 'bc1qnlz39q0r40xnv200s9wjutj0fdxex6x8abcdef';
 		$address_index = 22;
 
-		$bitcoin_wallet_factory    = new Bitcoin_Wallet_Factory();
-		$bitcoin_wallet_repository = new Bitcoin_Wallet_Repository( $bitcoin_wallet_factory );
-		$wallet                    = $bitcoin_wallet_repository->save_new( 'xpub1a2s3d4f5gabcdef' );
-
-		$bitcoin_address_factory    = new Bitcoin_Address_Factory( new JsonMapper_Helper()->build(), new ColorLogger() );
-		$bitcoin_address_repository = new Bitcoin_Address_Repository( $bitcoin_address_factory );
+		$wallet = $bitcoin_wallet_repository->save_new( 'xpub1a2s3d4f5gabcdef' );
 
 		$bitcoin_address = $bitcoin_address_repository->save_new_address(
 			wallet: $wallet,

--- a/tests/wpunit/admin/class-wallets-list-table-wpunit-Test.php
+++ b/tests/wpunit/admin/class-wallets-list-table-wpunit-Test.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace BrianHenryIE\WP_Bitcoin_Gateway\Admin;
+
+use BrianHenryIE\WP_Bitcoin_Gateway\API\Repositories\Bitcoin_Wallet_Repository;
+use BrianHenryIE\WP_Bitcoin_Gateway\API\Repositories\Factories\Bitcoin_Wallet_Factory;
+use BrianHenryIE\WP_Bitcoin_Gateway\API_Interface;
+use BrianHenryIE\WP_Bitcoin_Gateway\WP_Includes\Post_BH_Bitcoin_Wallet;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use WP_Post;
+use WP_Post_Type;
+
+/**
+ * @coversDefaultClass \BrianHenryIE\WP_Bitcoin_Gateway\Admin\Wallets_List_Table
+ *
+ * @phpstan-import-type Wallet_List_Table_Dependencies_Array from Wallets_List_Table
+ */
+class Wallets_List_Table_WPUnit_Test extends WPTestCase {
+
+	/**
+	 * The `$args` array used when constructing the Wallets_List_Table sut.
+	 *
+	 * @var array{screen:\WP_Screen}
+	 */
+	protected array $args;
+
+	/**
+	 * The sample WP_Post whose data we will "display".
+	 *
+	 * @var WP_Post
+	 */
+	protected WP_Post $post;
+
+	/**
+	 * @var Bitcoin_Wallet_Repository
+	 */
+	protected Bitcoin_Wallet_Repository $bitcoin_wallet_repository;
+
+	/**
+	 * @var API_Interface
+	 */
+	protected API_Interface $api;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		wp_set_current_user( 1 );
+
+		$this->api = $this->makeEmpty( API_Interface::class );
+
+		$bitcoin_wallet_factory          = new Bitcoin_Wallet_Factory();
+		$this->bitcoin_wallet_repository = new Bitcoin_Wallet_Repository( $bitcoin_wallet_factory );
+
+		$plugin_post_wallet_type = new Post_BH_Bitcoin_Wallet( $this->api, $this->bitcoin_wallet_repository );
+		$plugin_post_wallet_type->register_wallet_post_type();
+
+		$wallet = $this->bitcoin_wallet_repository->save_new( 'xpub1a2s3d4f5gabcdef' );
+
+		$this->post = get_post( $wallet->get_post_id() );
+
+		$screen            = \WP_Screen::get();
+		$screen->post_type = 'bh-bitcoin-wallet';
+
+		$this->args = array(
+			'screen' => $screen,
+		);
+	}
+
+	#[\Override]
+	public function tearDown(): void {
+		parent::tearDown();
+
+		/** @var array<string, WP_Post_Type> $wp_post_types */
+		global $wp_post_types;
+		unset( $wp_post_types['bh-bitcoin-wallet'] );
+	}
+
+	/**
+	 * Verify the constructor retrieves the dependencies from the post type object.
+	 *
+	 * The dependencies are registered via Post_BH_Bitcoin_Wallet::register_wallet_post_type()
+	 * and should be accessible on the WP_Post_Type object.
+	 *
+	 * @see Post_BH_Bitcoin_Wallet::register_wallet_post_type()
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor_retrieves_dependencies_from_post_type(): void {
+
+		/** @var WP_Post_Type&object{dependencies:Wallet_List_Table_Dependencies_Array} $post_type_object */
+		$post_type_object = get_post_type_object( 'bh-bitcoin-wallet' );
+
+		// The list table should be constructable and have the dependencies available.
+		$sut = new Wallets_List_Table( $this->args );
+
+		// Use reflection to verify the dependencies were set.
+		$reflection = new \ReflectionClass( $sut );
+
+		$api_property = $reflection->getProperty( 'api' );
+		$api_value    = $api_property->getValue( $sut );
+		$this->assertInstanceOf( API_Interface::class, $api_value );
+		$this->assertSame( $post_type_object->dependencies['api'], $api_value );
+
+		$bitcoin_wallet_repository_property = $reflection->getProperty( 'bitcoin_wallet_repository' );
+		$bitcoin_wallet_repository_value    = $bitcoin_wallet_repository_property->getValue( $sut );
+		$this->assertInstanceOf( Bitcoin_Wallet_Repository::class, $bitcoin_wallet_repository_value );
+		$this->assertSame( $post_type_object->dependencies['bitcoin_wallet_repository'], $bitcoin_wallet_repository_value );
+	}
+
+	/**
+	 * @covers ::column_status
+	 */
+	public function test_column_status(): void {
+
+		$sut = new Wallets_List_Table( $this->args );
+
+		ob_start();
+		$sut->column_status( $this->post );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'inactive', $output );
+	}
+}

--- a/tests/wpunit/wp-includes/class-post-bh-bitcoin-wallet-wpunit-Test.php
+++ b/tests/wpunit/wp-includes/class-post-bh-bitcoin-wallet-wpunit-Test.php
@@ -2,13 +2,19 @@
 
 namespace BrianHenryIE\WP_Bitcoin_Gateway\WP_Includes;
 
+use BrianHenryIE\WP_Bitcoin_Gateway\Admin\Wallets_List_Table;
+use BrianHenryIE\WP_Bitcoin_Gateway\API\Repositories\Bitcoin_Wallet_Repository;
+use BrianHenryIE\WP_Bitcoin_Gateway\API\Repositories\Factories\Bitcoin_Wallet_Factory;
 use BrianHenryIE\WP_Bitcoin_Gateway\API_Interface;
+use lucatume\WPBrowser\TestCase\WPTestCase;
 use WP_Post_Type;
 
 /**
  * @coversDefaultClass \BrianHenryIE\WP_Bitcoin_Gateway\WP_Includes\Post_BH_Bitcoin_Wallet
+ *
+ * @phpstan-import-type Wallet_List_Table_Dependencies_Array from Wallets_List_Table
  */
-class Post_BH_Bitcoin_Wallet_WPUnit_Test extends \lucatume\WPBrowser\TestCase\WPTestCase {
+class Post_BH_Bitcoin_Wallet_WPUnit_Test extends WPTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -18,15 +24,23 @@ class Post_BH_Bitcoin_Wallet_WPUnit_Test extends \lucatume\WPBrowser\TestCase\WP
 		unset( $wp_post_types['bh-bitcoin-address'] );
 	}
 
+	protected function get_sut(
+		?API_Interface $api = null,
+		?Bitcoin_Wallet_Repository $bitcoin_wallet_repository = null,
+	): Post_BH_Bitcoin_Wallet {
+		return new Post_BH_Bitcoin_Wallet(
+			api: $api ?? $this->makeEmpty( API_Interface::class ),
+			bitcoin_wallet_repository: $bitcoin_wallet_repository ?? new Bitcoin_Wallet_Repository( new Bitcoin_Wallet_Factory() ),
+		);
+	}
+
 	/**
 	 * @covers ::register_wallet_post_type
 	 * @covers ::__construct
 	 */
 	public function test_wallet_inactive_status(): void {
 
-		$api = $this->makeEmpty( API_Interface::class );
-
-		$sut = new Post_BH_Bitcoin_Wallet( $api );
+		$sut = $this->get_sut();
 
 		assert( ! post_type_exists( 'bh-bitcoin-wallet' ) );
 
@@ -35,5 +49,33 @@ class Post_BH_Bitcoin_Wallet_WPUnit_Test extends \lucatume\WPBrowser\TestCase\WP
 		$sut->register_wallet_post_type();
 
 		$this->assertContains( 'inactive', get_available_post_statuses( 'bh-bitcoin-wallet' ) );
+	}
+
+	/**
+	 * Verify register_post_type is called with dependencies in args.
+	 *
+	 * @covers ::register_wallet_post_type
+	 */
+	public function test_register_wallet_post_type_passes_dependencies(): void {
+
+		$api                       = $this->makeEmpty( API_Interface::class );
+		$bitcoin_wallet_repository = new Bitcoin_Wallet_Repository( new Bitcoin_Wallet_Factory() );
+
+		$sut = $this->get_sut( $api, $bitcoin_wallet_repository );
+
+		$sut->register_wallet_post_type();
+
+		/** @var WP_Post_Type&object{dependencies:Wallet_List_Table_Dependencies_Array} $post_type_object */
+		$post_type_object = get_post_type_object( 'bh-bitcoin-wallet' );
+
+		$this->assertNotNull( $post_type_object );
+		$this->assertTrue( isset( $post_type_object->dependencies ) );
+		$this->assertIsArray( $post_type_object->dependencies );
+
+		$this->assertArrayHasKey( 'api', $post_type_object->dependencies );
+		$this->assertSame( $api, $post_type_object->dependencies['api'] );
+
+		$this->assertArrayHasKey( 'bitcoin_wallet_repository', $post_type_object->dependencies );
+		$this->assertSame( $bitcoin_wallet_repository, $post_type_object->dependencies['bitcoin_wallet_repository'] );
 	}
 }


### PR DESCRIPTION
OpenClaw:

- Changed `Wallets_List_Table` to receive `Bitcoin_Wallet_Repository` via dependencies array on post type object (same pattern as `Addresses_List_Table`)
- Updated `Post_BH_Bitcoin_Wallet` constructor to accept repository dependencies
- Changed from 'plugin_objects' to 'dependencies' key in register_post_type
- Added `get_by_wp_post()` method to Bitcoin_Wallet_Repository
- Added unit test for `Post_BH_Bitcoin_Wallet` dependency passing
- Added WPUnit tests for `Wallets_List_Table`
- Updated addresses list table test to pass new dependencies