### PR TITLE
Fix/translate bitcoin metabox title

### DIFF
--- a/includes/api/clients/blockchain/class-blockchain-info-api.php
+++ b/includes/api/clients/blockchain/class-blockchain-info-api.php
@@ -79,7 +79,6 @@ class Blockchain_Info_Api implements Blockchain_API_Interface, LoggerAwareInterf
 
 		$adapter = new Blockchain_Info_Api_Transaction_Adapter();
 
-		// TODO: check this returns the array indexed by the txid.
 		return array_map(
 			$adapter->adapt( ... ),
 			$raw_address->getTxs()

--- a/includes/api/clients/interface-blockchain-api-interface.php
+++ b/includes/api/clients/interface-blockchain-api-interface.php
@@ -8,6 +8,12 @@ namespace BrianHenryIE\WP_Bitcoin_Gateway\API\Clients;
 use BrianHenryIE\WP_Bitcoin_Gateway\API\Model\Exceptions\Rate_Limit_Exception;
 use BrianHenryIE\WP_Bitcoin_Gateway\API\Model\Payments\Transaction;
 
+// I think we need every client to implement the ~`bh_wp_bitcoin_blockchain_api_link` descriptive filter to be able to
+// attribute the information we have with where it came from.
+//
+// . E.g. so we can get the
+// url to link to the details of a transaction. SO we can att
+
 interface Blockchain_API_Interface {
 
 	/**

--- a/includes/api/repositories/factories/class-bitcoin-transaction-factory.php
+++ b/includes/api/repositories/factories/class-bitcoin-transaction-factory.php
@@ -50,8 +50,6 @@ class Bitcoin_Transaction_Factory {
 	/**
 	 * Takes a WP_Post and gets the values (primitives?) to create a Bitcoin_Transaction.
 	 *
-	 * TODO: inject JsonMapper.
-	 *
 	 * @param WP_Post $post The backing WP_Post for this Bitcoin_Transaction.
 	 *
 	 * @throws BuilderException When the JSON mapper fails to deserialize the transaction data from post_content.

--- a/includes/integrations/woocommerce/class-admin-order-ui.php
+++ b/includes/integrations/woocommerce/class-admin-order-ui.php
@@ -99,7 +99,7 @@ class Admin_Order_UI {
 
 		add_meta_box(
 			'bh-wp-bitcoin-gateway',
-			'Bitcoin', // TODO: translate.
+			__( 'Bitcoin', 'bh-wp-bitcoin-gateway' ),
 			$this->print_address_transactions_metabox( ... ),
 			$screen,
 			'normal',


### PR DESCRIPTION
* `class-blockchain-info-api.php` TODO removed because nowhere uses the array keys.
* `interface-blockchain-api-interface.php` comment added about API design consideration
* `class-bitcoin-transaction-factory.php` removed outdated (completed) TODO
* `class-admin-order-ui.php` applied translations to the string
